### PR TITLE
fix: twitter_simple error

### DIFF
--- a/content/post/rich-content.md
+++ b/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+<!-- {{< twitter_simple 1085870671291310081 >}} -->
 
 <br>
 


### PR DESCRIPTION
Getting this error while deploying the site:
```
ERROR The "twitter_simple" shortcode requires two named parameters: user and id. See "/home/runner/work/tektite-website/tektite-website/content/post/rich-content.md:26:1"
```
Commenting out this line for now.